### PR TITLE
Emit pool activity

### DIFF
--- a/src/util/make-knex.js
+++ b/src/util/make-knex.js
@@ -135,6 +135,9 @@ export default function makeKnex(client) {
   client.on('query-response', function(response, obj, builder) {
     knex.emit('query-response', response, obj, builder)
   })
+  client.on('pool-activity', function(obj) {
+    knex.emit('pool-activity', obj)
+  })
 
   client.makeKnex = makeKnex
 


### PR DESCRIPTION
This patch gives us visibility on current [pool info](https://github.com/coopernurse/node-pool/tree/v2.5#pool-info). Each time the pool acquires or destroys a raw connection, there will be an event being emitted: `pool-activity`.

usage:

```js
const table = knex(options)
table.on('pool-activity', function(info) {
  console.log('INFO', info)
})
```
Output:

```js
INFO { master: 
   { action: 'acquire',
     name: 'postgresql:pg:client0',
     size: 2,
     availableObjectsCount: 1,
     waitingClientsCount: 0,
     maxPoolSize: 10,
     minPoolSize: 2 }

INFO { master: 
   { action: 'destroy',
     name: 'postgresql:pg:client0',
     size: 1,
     availableObjectsCount: 0,
     waitingClientsCount: 0,
     maxPoolSize: 10,
     minPoolSize: 2 },
  slave: 
   { action: 'destroy',
     name: 'postgresql:pg:client0:read',
     size: 2,
     availableObjectsCount: 0,
     waitingClientsCount: 0,
     maxPoolSize: 10,
     minPoolSize: 2 } }
```
