### PR TITLE
Use release() not end()

### DIFF
--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -139,7 +139,7 @@ assign(Client_PG.prototype, {
       master: getPoolInfo(this.pool, 'destroy'),
       slave: getPoolInfo(this.readReplicaPool, 'destroy')
     })
-    connection.end()
+    connection.release();
   },
 
   // In PostgreSQL, we need to do a version check to do some feature


### PR DESCRIPTION
Uh oh! Silly mistake! I was trying to use solely "run-in-the-pool" option but found this bug instead:sob: 